### PR TITLE
Drag bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-element-pan",
+  "name": "react-element-pan-modified",
   "version": "1.0.9",
   "description": "React component for allowing panning of DOM-elements too large for their container, in a Google Maps-like way.",
   "main": "src/element-pan.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-element-pan-modified",
+  "name": "react-element-pan",
   "version": "1.0.9",
   "description": "React component for allowing panning of DOM-elements too large for their container, in a Google Maps-like way.",
   "main": "src/element-pan.js",

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -44,7 +44,7 @@ var ElementPan = React.createClass({
         // If we have multiple child nodes, use the scroll[Height/Width]
         // If we have no child-nodes, use bounds to find size of inner content
         var bounds, target = e.currentTarget || e.target;
-        if (target.childNodes.length > 1) {
+        if (target.childNodes.length > 0) {
             bounds = { width: target.scrollWidth, height: target.scrollHeight };
         } else {
             bounds = e.target.getBoundingClientRect();

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -41,7 +41,7 @@ var ElementPan = React.createClass({
         eventListener.add(window, 'mouseup', this.onDragStop);
         eventListener.add(window, 'touchend', this.onDragStop);
 
-        // If we have multiple child nodes, use the scroll[Height/Width]
+        // If we have any child nodes, use the scroll[Height/Width]
         // If we have no child-nodes, use bounds to find size of inner content
         var bounds, target = e.currentTarget || e.target;
         if (target.childNodes.length > 0) {


### PR DESCRIPTION
- We were experiencing a bug when we panned an image with an SVG overlay that made the scroll position jump to the top left position onDragStart. This was caused by the `.getBoundingClientRect()` function randomly returning unexpectedly low values which caused the scroll positions to be set to minus numbers.

- To combat this I have modified the conditional on line 47 to set the `bounds.width/height` using `scrollWidth/Height` if any child nodes are present, rather than multiple child nodes. `.getBoundingClientRect()` is only used when no child nodes are present.